### PR TITLE
DogPush doesn't run on python 3

### DIFF
--- a/dogpush/__init__.py
+++ b/dogpush/__init__.py
@@ -1,0 +1,1 @@
+__all__ = [ 'dogpush', 'bcolors' ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-PyYAML==5.1.1
-datadog==0.20.0
-pytz==2018.4
-
+PyYAML==5.3.1
+datadog==0.35.0
+pytz==2019.3


### PR DESCRIPTION
Updated dependency versions, updated print statements and changed
iteration iteration operations on various dicts (in the creation
of option_defaults for example) in order for the module to run
on python 3.7.something.

There have been no attempts to improve much else, since that is not my
goal, though it is evident that much work is required to bring the
module to a state by which it could be said to "work reliably".

To me, getting the module to run is enough; effort is better spent
creating a cdk module or somethin' idk byeeeeeeeeeeeeee